### PR TITLE
chore: add Renovate config and SHA-pin GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ./go.mod
 
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ./go.mod
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver"
-  ],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
   "rebaseWhen": "conflicted",
   "timezone": "America/Los_Angeles",
   "schedule": ["after 10pm on sunday"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "rebaseWhen": "conflicted",
+  "timezone": "America/Los_Angeles",
+  "schedule": ["after 10pm on sunday"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 5,
+  "minimumReleaseAge": "30 days",
+  "enabledManagers": ["github-actions"],
+  "includePaths": [".github/**"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "schedule": ["at any time"],
+    "minimumReleaseAge": null
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions minor and patch updates",
+      "groupSlug": "github-actions-minor-patch"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "github-actions major updates",
+      "groupSlug": "github-actions-major"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["python"],
+      "enabled": false,
+      "description": "Do not auto-update Python runtime version; managed manually per pyproject.toml"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Renovate config for automated GitHub Actions dependency management
- SHA-pin all GitHub Actions to latest versions with semver comments

## Action upgrades
- `actions/checkout` v4 -> v6.0.2 (SHA-pinned)
- `actions/setup-go` v5 -> v6.4.0 (SHA-pinned)

## Breaking changes
- All actions now require Node 24 and GitHub Actions Runner v2.327.1+
- `actions/checkout` v6 and `actions/setup-go` v6 are major version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)